### PR TITLE
Passing mimetype to HttpResponse is deprecated and removed in Django 1.7

### DIFF
--- a/secretballot/views.py
+++ b/secretballot/views.py
@@ -8,7 +8,7 @@ from secretballot.models import Vote
 
 def vote(request, content_type, object_id, vote, can_vote_test=None,
          redirect_url=None, template_name=None, template_loader=loader,
-         extra_context=None, context_processors=None, mimetype=None):
+         extra_context=None, context_processors=None):
 
     # get the token from a SecretBallotMiddleware
     if not hasattr(request, 'secretballot_token'):
@@ -66,4 +66,4 @@ def vote(request, content_type, object_id, vote, can_vote_test=None,
         votes = Vote.objects.filter(content_type=content_type, object_id=object_id).count()
         body = '{"num_votes":%d}' % votes
 
-    return HttpResponse(body, content_type=mimetype)
+    return HttpResponse(body, content_type=content_type)


### PR DESCRIPTION
Not tested on Django < 1.7 though...